### PR TITLE
ChatGPTの情報をjsonにまとめた。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ crashlytics-build.properties
 
 # Ignore the large font asset file
 /Assets/Font/*
+chatgpt_config.json

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.44657886, g: 0.49641275, b: 0.5748176, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481676, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2818,7 +2818,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e9ac89f21310f45a085102c6214fedfe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  openAIApiKey: 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
+  loader: {fileID: 1947845783}
   modelVersion: gpt-4o
   maxTokens: 350
   temperature: 1
@@ -4427,6 +4427,53 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1800025464}
   m_CullTransparentMesh: 1
+--- !u!1 &1947845782
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1947845784}
+  - component: {fileID: 1947845783}
+  m_Layer: 0
+  m_Name: ChatGptConfig
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1947845783
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947845782}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5ed50e07f5b984c2484f1db61332445e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  config:
+    API_URL: 
+    API_KEY: 
+--- !u!4 &1947845784
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947845782}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1980335395
 GameObject:
   m_ObjectHideFlags: 0
@@ -4998,3 +5045,4 @@ SceneRoots:
   - {fileID: 1793950378}
   - {fileID: 1796852992}
   - {fileID: 1193883811}
+  - {fileID: 1947845784}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -2818,10 +2818,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e9ac89f21310f45a085102c6214fedfe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  loader: {fileID: 1947845783}
-  modelVersion: gpt-4o
-  maxTokens: 350
-  temperature: 1
+  configLoader: {fileID: 1947845783}
   initialSystemMessage: "# \u7269\u8A9E\u751F\u6210\n\n## \u524D\u63D0\n\u3042\u306A\u305F\u306F\u3001\u3042\u308B\u30B2\u30FC\u30E0\u306E\u30B2\u30FC\u30E0\u30DE\u30B9\u30BF\u30FC\u3067\u3059\u3002\u4EE5\u4E0B\u306E\u6307\u793A\u306B\u3057\u305F\u304C\u3063\u3066\u3001\u30B2\u30FC\u30E0\u306E\u52DD\u6557\u3092\u6C7A\u5B9A\u3057\u3001\u51FA\u529B\u3057\u3066\u304F\u3060\u3055\u3044\u3002\n\n##
     \u30B2\u30FC\u30E0\u5185\u5BB9\n- \u5F15\u304D\u6E21\u3057\u305F\u30B7\u30CA\u30EA\u30AA\u306F\u3001\u7570\u6027\u306E\u8EAB\u306E\u5B89\u5168\u304C\u5371\u3076\u307E\u308C\u308B\u72B6\u6CC1\u3067\u3059\u3002\n-
     \u30B2\u30FC\u30E0\u306E\u5185\u5BB9\u306F\u3001\u5F15\u304D\u6E21\u3057\u305F\u30B7\u30CA\u30EA\u30AA\u306B\u304A\u3051\u308B\u30D7\u30EC\u30A4\u30E4\u30FC\u306E\u884C\u52D5\u3067\u3001\u305D\u306E\u5F8C\u7570\u6027\u3068\u4ED8\u304D\u5408\u3046\u3053\u3068\u304C\u3067\u304D\u308B\u304B\u3092\u6C7A\u3081\u3001\u4ED8\u304D\u5408\u3048\u305F\u3089\u52DD\u5229\u3001\u4ED8\u304D\u5408\u3048\u306A\u304B\u3063\u305F\u3089\u6557\u5317\u3068\u3059\u308B\u3001\u3068\u3044\u3046\u3082\u306E\u3067\u3059\u3002\n\n##
@@ -4438,7 +4435,7 @@ GameObject:
   - component: {fileID: 1947845784}
   - component: {fileID: 1947845783}
   m_Layer: 0
-  m_Name: ChatGptConfig
+  m_Name: ConfigLoader
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4457,8 +4454,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   config:
+    MODEL: 
     API_URL: 
     API_KEY: 
+    MAX_TOKENS: 0
+    TEMPERATURE: 0
 --- !u!4 &1947845784
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ChatGPTScripts/ChatGPTConnection.cs
+++ b/Assets/Scripts/ChatGPTScripts/ChatGPTConnection.cs
@@ -4,42 +4,34 @@ using System.Text;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Networking;
-using UnityEngine.UI;
 
 namespace CHATGPT.OpenAI {
     public class ChatGPTConnection {
-        private readonly string _apiKey;
+        private readonly ChatGptConfig config;
         private readonly List<ChatGPTMessageModel> _messageList = new();// ユーザーとシステムのメッセージリスト
-        private readonly string _modelVersion;// 使用するChatGPTモデルのバージョン
-        private readonly int _maxTokens; // 生成する最大トークン数
-        private readonly float _temperature;  // モデルの応答のバリエーションを制御する
 
-        public ChatGPTConnection(string apiKey, string initialMessage, string modelVersion, int maxTokens, float temperature) {
-            _apiKey = apiKey;
+        public ChatGPTConnection(ChatGptConfig config, string initialMessage) {
+            this.config = config;
             _messageList.Add(new ChatGPTMessageModel() { role = "system", content = initialMessage });
-            _modelVersion = modelVersion;
-            _maxTokens = maxTokens; 
-            _temperature = temperature; 
         }
 
  // メッセージを送信して応答を受け取る非同期メソッド
         public async UniTask<ChatGPTResponseModel> RequestAsync(string userMessage) {
-            var apiUrl = "https://api.openai.com/v1/chat/completions";
             _messageList.Add(new ChatGPTMessageModel { role = "user", content = userMessage });
             var headers = new Dictionary<string, string> {
-                {"Authorization", "Bearer " + _apiKey},
+                {"Authorization", "Bearer " + config.API_KEY},
                 {"Content-type", "application/json"},
                 {"X-Slack-No-Retry", "1"}
             };
             var options = new ChatGPTCompletionRequestModel() {
-                model = _modelVersion,
+                model = config.MODEL,
                 messages = _messageList,
-                max_tokens = _maxTokens, 
-                temperature = _temperature 
+                max_tokens = config.MAX_TOKENS, 
+                temperature = config.TEMPERATURE 
             };
             var jsonOptions = JsonUtility.ToJson(options);
             Debug.Log("自分:" + userMessage);
-            using var request = new UnityWebRequest(apiUrl, "POST") {
+            using var request = new UnityWebRequest(config.API_URL, "POST") {
                 uploadHandler = new UploadHandlerRaw(Encoding.UTF8.GetBytes(jsonOptions)),
                 downloadHandler = new DownloadHandlerBuffer()
             };

--- a/Assets/Scripts/ChatGPTScripts/ChatGPTInteraction.cs
+++ b/Assets/Scripts/ChatGPTScripts/ChatGPTInteraction.cs
@@ -5,7 +5,7 @@ using CHATGPT.OpenAI;
 using System.Text.RegularExpressions;
 
 public class ChatGPTInteraction : MonoBehaviour {
-    [SerializeField] private ConfigLoader loader;
+    [SerializeField] private ConfigLoader configLoader;
     [TextArea]
     [SerializeField] private string initialSystemMessage = "これから、あるゲームのシナリオとプレイヤーの行動を渡します。これらのシナリオからプレイヤーの行動を考慮して、その後の物語がどのように展開し、プレイヤーが勝利するか敗北するかを決めてください。また、勝利の場合は最後に「モテる！」と記述してください。以下の詳細に従って出力してください。\n\n## ゲーム内容\n- 引き渡したシナリオは、異性の身の安全が危ぶまれる状況です。\n- ゲームの内容は、引き渡したシナリオにおけるプレイヤーの行動で、その後異性と付き合うことができるかを決め、付き合えたら勝利、付き合えなかったら敗北とする、というものです。\n\n## 指示\n- 渡されたシナリオとプレイヤーの行動から、そのシナリオからどのような行動結果になるか考えてください。\n- そのプレイヤーが最終的に好きな人からどのようなリアクションや返答などが得られるかについて考えてください。\n- 考えるシナリオは少し突飛なものであっても構わないものとする。\n- プレイヤーから行動を取得した時、基本的にはフラれること前提で出力してしまって構いません。本当にモテるやつ、もしくはユーモアの塊みたいなケースにのみモテる、という結果の出力になるような確率にしてください。\n\n## 出力フォーマット\n- アドバイスなどはせず、その行動からどのような物語になるかのみ、出力してください。\n- 勝利の場合、文章の最後に「モテる！」と出力してください。";
 
@@ -16,7 +16,7 @@ public class ChatGPTInteraction : MonoBehaviour {
     [SerializeField] private AnswerUIController answerUIController;
 
     void Start() {
-        chatGPTConnection = new ChatGPTConnection(loader.config, initialSystemMessage);
+        chatGPTConnection = new ChatGPTConnection(configLoader.config, initialSystemMessage);
         answerUIController = GetComponent<AnswerUIController>();
     }
 

--- a/Assets/Scripts/ChatGPTScripts/ChatGPTInteraction.cs
+++ b/Assets/Scripts/ChatGPTScripts/ChatGPTInteraction.cs
@@ -2,14 +2,10 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using CHATGPT.OpenAI;
-using Cysharp.Threading.Tasks;
 using System.Text.RegularExpressions;
 
 public class ChatGPTInteraction : MonoBehaviour {
-    [SerializeField] private string openAIApiKey;
-    [SerializeField] private string modelVersion = "gpt-4o";
-    [SerializeField] private int maxTokens = 350;
-    [SerializeField] private float temperature = 1f;
+    [SerializeField] private ConfigLoader loader;
     [TextArea]
     [SerializeField] private string initialSystemMessage = "これから、あるゲームのシナリオとプレイヤーの行動を渡します。これらのシナリオからプレイヤーの行動を考慮して、その後の物語がどのように展開し、プレイヤーが勝利するか敗北するかを決めてください。また、勝利の場合は最後に「モテる！」と記述してください。以下の詳細に従って出力してください。\n\n## ゲーム内容\n- 引き渡したシナリオは、異性の身の安全が危ぶまれる状況です。\n- ゲームの内容は、引き渡したシナリオにおけるプレイヤーの行動で、その後異性と付き合うことができるかを決め、付き合えたら勝利、付き合えなかったら敗北とする、というものです。\n\n## 指示\n- 渡されたシナリオとプレイヤーの行動から、そのシナリオからどのような行動結果になるか考えてください。\n- そのプレイヤーが最終的に好きな人からどのようなリアクションや返答などが得られるかについて考えてください。\n- 考えるシナリオは少し突飛なものであっても構わないものとする。\n- プレイヤーから行動を取得した時、基本的にはフラれること前提で出力してしまって構いません。本当にモテるやつ、もしくはユーモアの塊みたいなケースにのみモテる、という結果の出力になるような確率にしてください。\n\n## 出力フォーマット\n- アドバイスなどはせず、その行動からどのような物語になるかのみ、出力してください。\n- 勝利の場合、文章の最後に「モテる！」と出力してください。";
 
@@ -20,7 +16,7 @@ public class ChatGPTInteraction : MonoBehaviour {
     [SerializeField] private AnswerUIController answerUIController;
 
     void Start() {
-        chatGPTConnection = new ChatGPTConnection(openAIApiKey, initialSystemMessage, modelVersion, maxTokens, temperature);
+        chatGPTConnection = new ChatGPTConnection(loader.config, initialSystemMessage);
         answerUIController = GetComponent<AnswerUIController>();
     }
 

--- a/Assets/Scripts/ChatGptConfig.cs
+++ b/Assets/Scripts/ChatGptConfig.cs
@@ -1,0 +1,9 @@
+[System.Serializable]
+public class ChatGptConfig
+{
+    public string MODEL;
+    public string API_URL;
+    public string API_KEY;
+    public int MAX_TOKENS;
+    public float TEMPERATURE;
+}

--- a/Assets/Scripts/ChatGptConfig.cs.meta
+++ b/Assets/Scripts/ChatGptConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a295cbadd960a4ae180493a7e6acb7b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ConfigLoader.cs
+++ b/Assets/Scripts/ConfigLoader.cs
@@ -9,9 +9,6 @@ class ConfigLoader : MonoBehaviour
     void Start()
     {
         string json = File.ReadAllText("chatgpt_config.json");
-
-        Debug.Log(json != null);
-
         config = JsonUtility.FromJson<ChatGptConfig>(json);
     }
 }

--- a/Assets/Scripts/ConfigLoader.cs
+++ b/Assets/Scripts/ConfigLoader.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using UnityEngine;
+
+
+class ConfigLoader : MonoBehaviour
+{
+    public ChatGptConfig config;
+
+    void Start()
+    {
+        string json = File.ReadAllText("chatgpt_config.json");
+
+        Debug.Log(json != null);
+
+        config = JsonUtility.FromJson<ChatGptConfig>(json);
+        
+        Debug.Log(config.API_URL);
+        Debug.Log(config.API_KEY);
+        Debug.Log(config.MODEL);
+        Debug.Log(config.MAX_TOKENS);
+        Debug.Log(config.TEMPERATURE);
+    }
+}
+
+

--- a/Assets/Scripts/ConfigLoader.cs
+++ b/Assets/Scripts/ConfigLoader.cs
@@ -13,12 +13,6 @@ class ConfigLoader : MonoBehaviour
         Debug.Log(json != null);
 
         config = JsonUtility.FromJson<ChatGptConfig>(json);
-        
-        Debug.Log(config.API_URL);
-        Debug.Log(config.API_KEY);
-        Debug.Log(config.MODEL);
-        Debug.Log(config.MAX_TOKENS);
-        Debug.Log(config.TEMPERATURE);
     }
 }
 

--- a/Assets/Scripts/ConfigLoader.cs.meta
+++ b/Assets/Scripts/ConfigLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ed50e07f5b984c2484f1db61332445e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/chatgpt_config.json.sample
+++ b/chatgpt_config.json.sample
@@ -1,0 +1,7 @@
+{
+    "MODEL": "gpt-4o",
+    "API_URL": "https://api.openai.com/v1/chat/completions",
+    "API_KEY": "Your api key",
+    "MAX_TOKENS": 150,
+    "TEMPERATURE": 1.0
+}


### PR DESCRIPTION
## なぜやったのか
- APIKeyがGitHubに公開されている状態はセキュリティ的に脅威になる。
- ChatGPTの構成がバラバラに定義されていて管理がしにくい。
## やったこと
- ChatGptの構成設定をconfig.jsonファイルにまとめた。
- .gitignoreに'chatgpt_config.json'を追加 
- ConfigLoader.cs の実装。

### config.jsonにまとめた情報
- モデルバージョン(gpt-4o)
- ApiURL
- ApiKey
- MAX_TOKENS
- TEMPERATURE

## fetchした後に動かすには
1. `chatgpt_config.json` を作成する。(.gitignoreと同階層)
2. `chatgpt_config.json.sample` を `chatgpt_config.json` にコピペする。
3.  各自で`chatgpt_config.json` のAPI_KEYを入力する。
4. 万が一、間違えて`chatgpt_config.json`をpushしないように気をつける。

## 動作確認
実行したところ、ちゃんとchatGPTのレスポンスが入手できた。